### PR TITLE
Provide an octave example.

### DIFF
--- a/examples/octave.rs
+++ b/examples/octave.rs
@@ -1,0 +1,13 @@
+#![feature(proc_macro_hygiene)]
+
+use inline_python::{python, Context};
+
+fn main() {
+    let c: Context = python! {
+            import oct2py
+            oc = oct2py.Oct2Py()
+            m = oc.magic(3)
+		};
+
+    dbg!(c.get::<Vec<Vec<f64>>>("m"));
+}


### PR DESCRIPTION
Just to prove you can run GNU Octave via oct2py from Rust via inline-python. Requires octave-cli installation and OCTAVE alias of the CLI path.