### PR TITLE
Upgrade to PyO3 0.10.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,3 +13,5 @@ jobs:
       run: cargo +nightly build --verbose
     - name: Run tests
       run: cargo +nightly test --verbose
+    - name: Build examples
+      run: cd examples && cargo +nightly build --all --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,6 @@ keywords = ["python", "inline", "embed", "macro"]
 
 [dependencies]
 inline-python-macros = { version = "=0.5.0", path = "./macros" }
-pyo3 = "0.9.0"
+pyo3 = { version = "0.10.0", default-features = false }
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,11 @@ license = "BSD-2-Clause"
 edition = "2018"
 repository = "https://github.com/fusion-engineering/inline-python"
 keywords = ["python", "inline", "embed", "macro"]
+autoexamples = false
 
 [dependencies]
 inline-python-macros = { version = "=0.5.0", path = "./macros" }
 pyo3 = { version = "0.10.0", default-features = false }
 
 [workspace]
+members = ["examples"]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "inline-python-examples"
+version = "0.0.0"
+
+[[example]]
+name = "context"
+path = "context.rs"
+
+[[example]]
+name = "matplotlib"
+path = "matplotlib.rs"
+
+[[example]]
+name = "rust-fn"
+path = "rust-fn.rs"
+
+[dependencies]
+inline-python = { path = ".." }
+pyo3 = "0.10.0"

--- a/examples/rust-fn.rs
+++ b/examples/rust-fn.rs
@@ -1,7 +1,7 @@
 #![feature(proc_macro_hygiene)]
 
-use inline_python::pyo3::{self, prelude::*, wrap_pyfunction};
 use inline_python::{python, Context};
+use pyo3::{prelude::*, wrap_pyfunction};
 
 #[pyfunction]
 fn rust_print(x: i32) {

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -16,4 +16,4 @@ proc_macro = true
 [dependencies]
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
 quote = "1.0"
-pyo3 = "0.9.0"
+pyo3 = { version = "0.10.0", default-features = false }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -6,7 +6,7 @@ extern crate proc_macro;
 use self::embed_python::EmbedPython;
 use proc_macro::TokenStream as TokenStream1;
 use proc_macro2::{Literal, Span, TokenStream};
-use pyo3::{ffi, types::PyBytes, AsPyPointer, FromPyPointer, ObjectProtocol, PyErr, PyObject, Python, ToPyObject};
+use pyo3::{ffi, types::PyBytes, AsPyPointer, FromPyPointer, PyErr, PyObject, Python, ToPyObject};
 use quote::quote;
 use std::ffi::CString;
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -130,10 +130,10 @@ impl Context {
 	///
 	/// Use this with `pyo3::wrap_pyfunction` or `pyo3::wrap_pymodule`.
 	///
-	/// ```
+	/// ```ignore
 	/// # #![feature(proc_macro_hygiene)]
 	/// # use inline_python::{Context, python};
-	/// use inline_python::pyo3::{self, prelude::*, wrap_pyfunction};
+	/// use pyo3::{prelude::*, wrap_pyfunction};
 	///
 	/// #[pyfunction]
 	/// fn get_five() -> i32 {


### PR DESCRIPTION
In PyO3 0.10 we disable the `macros` feature, to significantly reduce the dependencies:

Before:
```
   Compiling proc-macro2 v1.0.6
   Compiling unicode-xid v0.2.0
   Compiling syn v1.0.9
   Compiling serde v1.0.103
   Compiling ryu v1.0.2
   Compiling libc v0.2.66
   Compiling regex-syntax v0.6.12
   Compiling autocfg v0.1.7
   Compiling itoa v0.4.4
   Compiling smallvec v1.3.0
   Compiling cfg-if v0.1.10
   Compiling unindent v0.1.5
   Compiling version_check v0.9.1
   Compiling scopeguard v1.1.0
   Compiling lock_api v0.3.4
   Compiling num-traits v0.2.10
   Compiling quote v1.0.2
   Compiling parking_lot_core v0.7.1
   Compiling parking_lot v0.10.2
   Compiling regex v1.3.1
   Compiling pyo3-derive-backend v0.9.2
   Compiling proc-macro-hack v0.5.11
   Compiling serde_derive v1.0.103
   Compiling ghost v0.1.1
   Compiling inventory-impl v0.1.4
   Compiling ctor v0.1.12
   Compiling pyo3cls v0.9.2
   Compiling paste-impl v0.1.6
   Compiling indoc-impl v0.3.4
   Compiling inventory v0.1.4
   Compiling indoc v0.3.4
   Compiling paste v0.1.6
   Compiling serde_json v1.0.42
   Compiling pyo3 v0.9.2
   Compiling inline-python-macros v0.5.0
   Compiling inline-python v0.5.1
    Finished dev [unoptimized + debuginfo] target(s) in 29.96s
```

After:
```
   Compiling version_check v0.9.1
   Compiling proc-macro2 v1.0.6
   Compiling libc v0.2.66
   Compiling unicode-xid v0.2.0
   Compiling pyo3 v0.10.0
   Compiling quote v1.0.2
   Compiling inline-python-macros v0.5.0
   Compiling inline-python v0.5.1
    Finished dev [unoptimized + debuginfo] target(s) in 6.17s
```