### PR TITLE
Make Context::add_wrapped_with_gil use set_with_gil

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -163,7 +163,7 @@ impl Context {
 	pub fn add_wrapped_with_gil<'p>(&self, py: Python<'p>, wrapper: &impl Fn(Python) -> PyObject) {
 		let obj = wrapper(py);
 		let name = obj.getattr(py, "__name__").expect("Missing __name__");
-		self.set(name.extract(py).unwrap(), obj)
+		self.set_with_gil(py, name.extract(py).unwrap(), obj)
 	}
 
 	/// Run Python code using this context.


### PR DESCRIPTION
When we already have a gil, we shouldn't capture another one (does this even work?)