### PR TITLE
Cause syntax error when assigning to 'var

### DIFF
--- a/macros/src/embed_python.rs
+++ b/macros/src/embed_python.rs
@@ -79,7 +79,7 @@ impl EmbedPython {
 							unreachable!()
 						};
 						let name_str = format!("_RUST_{}", name);
-						self.python.push_str(&name_str);
+						self.python.push_str(&format!("((lambda:{})())", name_str));
 						self.loc.column += name_str.chars().count() - 6 + 1;
 						self.variables.entry(name_str).or_insert(name);
 					} else if x.as_char() == '#' && x.spacing() == Spacing::Joint {

--- a/macros/src/error.rs
+++ b/macros/src/error.rs
@@ -18,7 +18,10 @@ pub fn compile_error_msg(py: Python, error: PyErr, tokens: TokenStream) -> Token
 		let msg: Option<String> = value.getattr(py, "msg").ok().and_then(|x| x.extract(py).ok());
 		if let (Some(line), Some(msg)) = (line, msg) {
 			if let Some(span) = span_for_line(tokens.clone(), line) {
-				let error = format!("python: {}", msg);
+				let mut error = format!("python: {}", msg);
+				if msg == "cannot assign to function call" {
+					error += ". LIKELY CAUSE: you cannot assign to RUST-Variables, see Context::get_global() instead";
+				}
 				return quote_spanned!(span.into() => compile_error!{#error});
 			}
 		}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@
 //!
 //! To reference Rust variables, use `'var`, as shown in the example above.
 //! `var` needs to implement [`pyo3::ToPyObject`].
+//! Do not assign to a `'var`, it will cause a Syntax Error `cannot assign to function call`.
 //!
 //! ## Re-using a Python context
 //!
@@ -69,6 +70,17 @@
 //! };
 //!
 //! assert_eq!(c.get::<i32>("foo"), 5);
+//! ```
+//!
+//! ## Compile Errors
+//! The python code is compiled when the rust code is compiled, so syntax errors are emitted by
+//! `rustc` and not at runtime. They should show up in your IDE.
+//!
+//! Changing rust variables will cause a syntax error because they are implemented as
+//! `((lambda:value)())`
+//! ```compile_fail
+//! # use inline_python::python;
+//! python!{ 'x = 42 }
 //! ```
 //!
 //! ## Syntax issues


### PR DESCRIPTION

You can cause a Syntaxerror for assignments to rust variables by expanding them to `((lambda:_RUST_var)())`

Since the SyntaxError has a very confusing message, the likely cause is appended:

```
error: python: cannot assign to function call. LIKELY CAUSE: you cannot assign to RUST-Variables, see Context::get_global() instead
 --> examples/readonly.rs:6:9
  |
6 |         'x = 42;
  |         ^^^^^^^^

error: aborting due to previous error
```

The Error message could be improved by inspecting the code it is raised for, but I don't know how to do it reliably.