### PR TITLE
Add pyo3 feature forwarding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,17 @@ autoexamples = false
 inline-python-macros = { version = "=0.7.0", path = "./macros" }
 pyo3 = { version = "0.14.0", default-features = false, features = ["auto-initialize"] }
 
+[features]
+pyo3-macros = ["pyo3/macros"]
+pyo3-multiple-pymethods = ["pyo3/multiple-pymethods"]
+pyo3-extension-module = ["pyo3/extension-module"]
+pyo3-abi3 = ["pyo3/abi3"]
+pyo3-abi3-py36 = ["pyo3/abi3-py36"]
+pyo3-abi3-py37 = ["pyo3/abi3-py37"]
+pyo3-abi3-py38 = ["pyo3/abi3-py38"]
+pyo3-abi3-py39 = ["pyo3/abi3-py39"]
+pyo3-auto-initialize = ["pyo3/auto-initialize"]
+pyo3-nightly = ["pyo3/nightly"]
+
 [workspace]
 members = ["examples", "ct-python"]


### PR DESCRIPTION
This is to allow users to directly control the features of the pyo3 instance used by inline-python without adding it as a direct dependency (and thus risking the versions of pyo3 drifting out of date without pinning both libraries versions). This is especially useful as inline-python re-exports pyo3.

The format used is "pyo3-{featurename}", following the kebab case of pyo3's features.