### PR TITLE
Return custom error instead of panic

### DIFF
--- a/examples/context.rs
+++ b/examples/context.rs
@@ -23,7 +23,7 @@ fn main() {
 		foo += 10
 	});
 
-	let x: i32 = result.get("foo");
+	let x: i32 = result.get("foo").unwrap();
 
 	assert_eq!(x, 137);
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,17 @@
+/// Error indicating why a variable value could not be returned
+#[derive(Debug)]
+pub enum PyVarError {
+	NotFound(String, String),
+	WrongType(String),
+}
+
+impl std::error::Error for PyVarError {}
+
+impl std::fmt::Display for PyVarError {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			PyVarError::NotFound(name, r#type) => write!(f, "Unable to convert `{name}` to `{type}`"),
+			PyVarError::WrongType(name) => write!(f, "Python context does not contain a variable named `{name}`"),
+		}
+	}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@
 //!   foo = 5
 //! };
 //!
-//! assert_eq!(c.get::<i32>("foo"), 5);
+//! assert_eq!(c.get::<i32>("foo").unwrap(), 5);
 //! ```
 //!
 //! ## Syntax issues
@@ -112,8 +112,10 @@ use pyo3::{types::PyDict, Python};
 
 mod context;
 mod run;
+mod error;
 
 pub use self::context::Context;
+pub use error::PyVarError;
 pub use pyo3;
 
 /// A block of Python code within your Rust code.

--- a/tests/shared_context.rs
+++ b/tests/shared_context.rs
@@ -1,4 +1,4 @@
-use inline_python::python;
+use inline_python::{python, PyVarError};
 
 #[test]
 fn continue_context() {
@@ -19,5 +19,27 @@ fn extract_global() {
 		foo = 5
 	});
 
-	assert_eq!(c.get::<i32>("foo"), 5);
+	assert_eq!(c.get::<i32>("foo").unwrap(), 5);
+}
+
+#[test]
+fn wrong_type() {
+	let c = inline_python::Context::new();
+
+	c.run(python! {
+		foo = 5
+	});
+
+	assert!(matches!(c.get::<String>("foo").unwrap_err(), PyVarError::WrongType(_)));
+}
+
+#[test]
+fn not_found() {
+	let c = inline_python::Context::new();
+
+	c.run(python! {
+		foo = 5
+	});
+
+	assert!(matches!(c.get::<i32>("bar").unwrap_err(), PyVarError::NotFound(_, _)));
 }


### PR DESCRIPTION
I checked your project and saw that when trying to get a variable you use `panic!` for error handling. I think it's better to return a custom error to allow users to handle the error instead of just terminating the program.