### PR TITLE
chore: upgrade pyo3 to 0.18.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ autoexamples = false
 
 [dependencies]
 inline-python-macros = { version = "=0.10.0", path = "./macros" }
-pyo3 = { version = "0.17.0", default-features = false, features = ["auto-initialize"] }
+pyo3 = { version = "0.18.0", default-features = false, features = ["auto-initialize"] }
 
 [workspace]
 members = ["examples", "ct-python"]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -17,4 +17,4 @@ path = "rust-fn.rs"
 
 [dependencies]
 inline-python = { path = ".." }
-pyo3 = "0.17.0"
+pyo3 = "0.18.0"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -16,7 +16,7 @@ proc_macro = true
 [dependencies]
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
 quote = "1.0"
-pyo3 = { version = "0.17.0", default-features = false, features = ["auto-initialize"] }
+pyo3 = { version = "0.18.0", default-features = false, features = ["auto-initialize"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.71"


### PR DESCRIPTION
This upgrades to the latest release of pyo3. I found no issues on my end.