### PR TITLE
Fix breakage after proc_macro LineColumn/Spam changes

### DIFF
--- a/macros/src/error.rs
+++ b/macros/src/error.rs
@@ -53,8 +53,8 @@ fn span_for_line(input: TokenStream, line: usize) -> Option<Span> {
 	let mut spans = input
 		.into_iter()
 		.map(|x| x.span().unwrap())
-		.skip_while(|span| span.start().line < line)
-		.take_while(|span| span.start().line == line);
+		.skip_while(|span| span.start().line() < line)
+		.take_while(|span| span.start().line() == line);
 
 	let mut result = spans.next()?;
 	for span in spans {


### PR DESCRIPTION
needs for nightly rustc (LineColumn removed from proc_macro, seems like)

maybe it's possible to do fix in a better way but I'm not very good with proc_macro